### PR TITLE
Make global variables extern to avoid multiple definition errors

### DIFF
--- a/src/opencl.c
+++ b/src/opencl.c
@@ -26,6 +26,14 @@ int ngpusg;
 __thread int opencl_device_id_t;
 __thread int opencl_device_ct_t;
 
+cl_int *cl_native_double_width_s;
+size_t *cl_native_max_group_size_s;
+size_t *cl_native_address_bits_s;
+
+cl_context opencl_context;
+cl_command_queue* opencl_queues;
+cl_device_id* opencl_devices;
+
 cl_context_properties* cl_props;
 
 const char* clGetErrorString(int errorCode) {
@@ -549,7 +557,7 @@ void opencl_kernel_local(cl_kernel kernel, const dim2 globalItemSize, const dim2
     size_t localItems[2];
     localItems[0] = localItemSize.x;
     localItems[1] = localItemSize.y;
-    
+
 #ifdef BENCHMARK
     clock_t t;
     t = clock();

--- a/src/opencl.h
+++ b/src/opencl.h
@@ -33,9 +33,9 @@ extern int ngpusg;
 extern __thread int opencl_device_id_t;
 extern __thread int opencl_device_ct_t;
 
-cl_int *cl_native_double_width_s;
-size_t *cl_native_max_group_size_s;
-size_t *cl_native_address_bits_s;
+extern cl_int *cl_native_double_width_s;
+extern size_t *cl_native_max_group_size_s;
+extern size_t *cl_native_address_bits_s;
 
 typedef struct _cl_mem_ext cl_mem_ext;
 
@@ -65,9 +65,9 @@ cl_mem_ext rem(cl_mem_ext buf, int dec, size_t len);
 cl_mem_ext upd(cl_mem_ext buf, size_t len);
 cl_command_queue que();
 
-cl_context opencl_context;
-cl_command_queue* opencl_queues;
-cl_device_id* opencl_devices;
+extern cl_context opencl_context;
+extern cl_command_queue* opencl_queues;
+extern cl_device_id* opencl_devices;
 
 void activation_kernel_init(void);
 void blas_kernel_init(void);


### PR DESCRIPTION
Fixes #48 